### PR TITLE
Release 0.2.0 - Feat: fast unity catalog indexing, skip legacy metastore indexing, code formatting, types and test fixes

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -28,17 +28,19 @@ jobs:
     - name: Install dependencies and build
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-        python setup.py sdist bdist_wheel
+        pip install poetry
+        poetry build
 
     - name: Publish to TestPyPI
       env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TESTPYPI_API_TOKEN }}
-      run: twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+        USERNAME: __token__
+        PASSWORD: ${{ secrets.TESTPYPI_API_TOKEN }}
+      run: |
+        poetry config repositories.test-pypi https://test.pypi.org/legacy/
+        poetry publish -r test-pypi -u "$USERNAME" -p "$PASSWORD"
 
     - name: Publish to PyPI
       env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload dist/*
+        USERNAME: __token__
+        PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: poetry publish -u "$USERNAME" -p "$PASSWORD"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-02-09
+
+### Features
+
+-   Faster indexing for Unity Catalog assets. Makes loading & refreshing Harlequin's Data Catalog
+pane much quicker for Databricks instances running Unity Catalog. The new method fetches metadata
+for Unity Catalog assets from `system.information_schema`, requiring only two SQL queries to do so.
+This is much faster than the old method, which required separate SQL calls for each table. The old
+method is still in use for indexing legacy metastores (e.g. `hive_metastore`) however, as that
+metadata is not contained in Information schema:
+https://docs.databricks.com/en/sql/language-manual/sql-ref-information-schema.html
+-   Add new command line flag `--skip-legacy-indexing` to skip the indexing of legacy metastores.
+Setting this flag is recommended if your Databricks instance runs Unity Catalog and you do not want
+the overhead of slow indexing of legacy metastores. When this flag is set, only Unity Catalog
+assets will show up in the Data Catalog pane.
+
 ## [0.1.1] - 2024-02-08
 
 ### Bug Fixes
@@ -17,7 +33,9 @@ All notable changes to this project will be documented in this file.
 
 -   Adds a Databricks adapter for SQL warehouses and DBR interactive clusters.
 
-[Unreleased]: https://github.com/alexmalins/harlequin-databricks/compare/0.1.1...HEAD
+[Unreleased]: https://github.com/alexmalins/harlequin-databricks/compare/0.2.0...HEAD
+
+[0.2.0]: https://github.com/alexmalins/harlequin-databricks/compare/0.1.1...0.2.0
 
 [0.1.1]: https://github.com/alexmalins/harlequin-databricks/compare/0.1.0...0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.2.0] - 2024-02-09
+## [0.2.0] - 2024-02-10
 
 ### Features
 
@@ -23,6 +23,8 @@ assets will show up in the Data Catalog pane.
 ### Bug Fixes
 
 -   Fix minor formatting (black), types (mypy) & linting (ruff) issues, and a test failure.
+-   Don't use underscores in CLI option names, i.e. make it so the only acceptable option version
+is the one written with hyphens not underscores.
 
 ## [0.1.1] - 2024-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Setting this flag is recommended if your Databricks instance runs Unity Catalog 
 the overhead of slow indexing of legacy metastores. When this flag is set, only Unity Catalog
 assets will show up in the Data Catalog pane.
 
+### Bug Fixes
+
+-   Fix minor formatting (black), types (mypy) & linting (ruff) issues, and a test failure.
+
 ## [0.1.1] - 2024-02-08
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ harlequin --help
 For more information, see the
 [harlequin-databricks Docs](https://harlequin.sh/docs/databricks/index).
 
+## Using Unity Catalog and want fast Data Catalog indexing?
+
+Supply the `--skip-legacy-indexing` command line flag if you do not care about legacy metastores
+(e.g. `hive_metastore`) being indexed in Harlequin's Data Catalog pane.
+
+This flag will skip indexing of old non-Unity Catalog metastores (i.e. they won't appear in the
+Data Catalog pane with this flag).
+
+Because of the way legacy Databricks metastores works, a separate SQL query is required to fetch
+the metadata of each table in a legacy metastore. This means indexing them for Harlequin's Data Catalog pane is slow.
+
+Databricks's Unity Catalog upgrade brought
+[Information Schema](https://docs.databricks.com/en/sql/language-manual/sql-ref-information-schema.html),
+which allows harlequin-databricks to fetch metadata for all Unity Catalog assets with only two SQL queries.
+
+So if your Databricks instance is running Unity Catalog, and you no longer care about the legacy
+metastores, setting the `--skip-legacy-indexing` CLI flag is recommended as it will mean
+much faster indexing & refreshing of the assets in the Data Catalog pane.
+
 ## Issues, Contributions and Feature Requests
 
 Please report bugs/issues with this adapter via the GitHub

--- a/poetry.lock
+++ b/poetry.lock
@@ -999,6 +999,36 @@ test = ["hypothesis (>=6.34.2)", "pytest (>=7.3.2)", "pytest-asyncio (>=0.17.0)"
 xml = ["lxml (>=4.6.3)"]
 
 [[package]]
+name = "pandas-stubs"
+version = "2.0.2.230605"
+description = "Type annotations for pandas"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pandas_stubs-2.0.2.230605-py3-none-any.whl", hash = "sha256:39106b602f3cb6dc5f728b84e1b32bde6ecf41ee34ee714c66228009609fbada"},
+    {file = "pandas_stubs-2.0.2.230605.tar.gz", hash = "sha256:624c7bb06d38145a44b61be459ccd19b038e0bf20364a025ecaab78fea65e858"},
+]
+
+[package.dependencies]
+numpy = ">=1.24.3"
+types-pytz = ">=2022.1.1"
+
+[[package]]
+name = "pandas-stubs"
+version = "2.0.3.230814"
+description = "Type annotations for pandas"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pandas_stubs-2.0.3.230814-py3-none-any.whl", hash = "sha256:4b3dfc027d49779176b7daa031a3405f7b839bcb6e312f4b9f29fea5feec5b4f"},
+    {file = "pandas_stubs-2.0.3.230814.tar.gz", hash = "sha256:1d5cc09e36e3d9f9a1ed9dceae4e03eeb26d1b898dd769996925f784365c8769"},
+]
+
+[package.dependencies]
+numpy = {version = ">=1.25.0", markers = "python_version >= \"3.9\""}
+types-pytz = ">=2022.1.1"
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -1693,6 +1723,56 @@ files = [
 tree-sitter = "*"
 
 [[package]]
+name = "types-beautifulsoup4"
+version = "4.12.0.20240106"
+description = "Typing stubs for beautifulsoup4"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-beautifulsoup4-4.12.0.20240106.tar.gz", hash = "sha256:98d628985b71b140bd3bc22a8cb0ab603c2f2d08f20d37925965eb4a21739be8"},
+    {file = "types_beautifulsoup4-4.12.0.20240106-py3-none-any.whl", hash = "sha256:cbdd60ab8aeac737ac014431b6e921b43e84279c0405fdd25a6900bb0e71da5b"},
+]
+
+[package.dependencies]
+types-html5lib = "*"
+
+[[package]]
+name = "types-html5lib"
+version = "1.1.11.20240106"
+description = "Typing stubs for html5lib"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-html5lib-1.1.11.20240106.tar.gz", hash = "sha256:fc3a1b18eb601b3eeaf92c900bd67675c0a4fa1dd1d2a2893ebdb46923547ee9"},
+    {file = "types_html5lib-1.1.11.20240106-py3-none-any.whl", hash = "sha256:61993cb89220107481e0f1da65c388ff8cf3d8c5f6e8483c97559639a596b697"},
+]
+
+[[package]]
+name = "types-pytz"
+version = "2024.1.0.20240203"
+description = "Typing stubs for pytz"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-pytz-2024.1.0.20240203.tar.gz", hash = "sha256:c93751ee20dfc6e054a0148f8f5227b9a00b79c90a4d3c9f464711a73179c89e"},
+    {file = "types_pytz-2024.1.0.20240203-py3-none-any.whl", hash = "sha256:9679eef0365db3af91ef7722c199dbb75ee5c1b67e3c4dd7bfbeb1b8a71c21a3"},
+]
+
+[[package]]
+name = "types-requests"
+version = "2.31.0.20240125"
+description = "Typing stubs for requests"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-requests-2.31.0.20240125.tar.gz", hash = "sha256:03a28ce1d7cd54199148e043b2079cdded22d6795d19a2c2a6791a4b2b5e2eb5"},
+    {file = "types_requests-2.31.0.20240125-py3-none-any.whl", hash = "sha256:9592a9a4cb92d6d75d9b491a41477272b710e021011a2a3061157e2fb1f1a5d1"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
+
+[[package]]
 name = "typing-extensions"
 version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -1794,4 +1874,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "792798b1e4e77a6356baeac397c2332e0e62ef8e4b19d67039025f74d0c1a302"
+content-hash = "158ee03fcad49788328c60dbf1ee70470697d33e6348a941509a3064951c3718"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1716,13 +1716,13 @@ files = [
 
 [[package]]
 name = "uc-micro-py"
-version = "1.0.2"
+version = "1.0.3"
 description = "Micro subset of unicode data files for linkify-it-py projects."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "uc-micro-py-1.0.2.tar.gz", hash = "sha256:30ae2ac9c49f39ac6dce743bd187fcd2b574b16ca095fa74cd9396795c954c54"},
-    {file = "uc_micro_py-1.0.2-py3-none-any.whl", hash = "sha256:8c9110c309db9d9e87302e2f4ad2c3152770930d88ab385cd544e7a7e75f3de0"},
+    {file = "uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a"},
+    {file = "uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harlequin-databricks"
-version = "0.1.1"
+version = "0.2.0"
 description = "A Harlequin adapter for Databricks."
 authors = [
     "Zach Shirah <zachshirah01@gmail.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,12 @@ mypy = "^1.7.0"
 pre-commit = "^3.5.0"
 importlib_metadata = { version = ">=4.6.0", python = "<3.10.0" }
 beautifulsoup4 = "^4.12.3"
+types-beautifulsoup4 = "^4.12.0.0"
 lxml = "^5.1.0"
 pandas = "^2.0.0"
+pandas-stubs = "^2.0.0.230412"
 requests = "^2.0.0"
+types-requests = "^2.25.0"
 
 [tool.poetry.urls]
 changelog = "https://github.com/alexmalins/harlequin-databricks/blob/main/CHANGELOG.md"

--- a/scripts/scrape_keywords.py
+++ b/scripts/scrape_keywords.py
@@ -1,16 +1,17 @@
+from __future__ import annotations
+
 import csv
 from pathlib import Path
 
 import requests
 from bs4 import BeautifulSoup
 
-
 # Databricks's SQL keywords page was last updated October 10, 2023. It is archived at:
 # https://web.archive.org/web/20240122080239/https://docs.databricks.com/en/sql/language-manual/sql-ref-reserved-words.html
 URL = "https://docs.databricks.com/en/sql/language-manual/sql-ref-reserved-words.html"
 
 
-def scrape_keywords() -> None:
+def scrape_keywords() -> list[str]:
     page = requests.get(URL)
     soup = BeautifulSoup(page.content, "html.parser")
 

--- a/src/harlequin_databricks/adapter.py
+++ b/src/harlequin_databricks/adapter.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any
 
-import pyarrow as pa
 import pyarrow.compute as pc
 from databricks import sql as databricks_sql
 from databricks.sql.client import Cursor as DatabricksCursor
@@ -103,7 +102,7 @@ class HarlequinDatabricksConnection(HarlequinConnection):
     def execute(self, query: str) -> HarlequinDatabricksCursor:
         try:
             cur = self.conn.cursor()
-            cur.execute(query)  # type: ignore
+            cur.execute(query)
         except Exception as e:
             cur.close()
             raise HarlequinQueryError(
@@ -127,7 +126,8 @@ class HarlequinDatabricksConnection(HarlequinConnection):
 
             for catalog_arrow in catalogs["TABLE_CAT"]:
                 catalog = catalog_arrow.as_py()
-                if catalog in seen_catalogs: continue
+                if catalog in seen_catalogs:
+                    continue
                 seen_catalogs.append(catalog)
 
                 cursor.schemas(catalog_name=catalog)
@@ -198,7 +198,8 @@ class HarlequinDatabricksConnection(HarlequinConnection):
                 )
             # Sort the catalogs again to ensure legacy and unity catalogs appear alphabetically:
             catalog_items = [
-                catalog_item for _, catalog_item in sorted(zip(seen_catalogs, catalog_items))
+                catalog_item
+                for _, catalog_item in sorted(zip(seen_catalogs, catalog_items))
             ]
             return Catalog(items=catalog_items)
 
@@ -235,11 +236,13 @@ class HarlequinDatabricksConnection(HarlequinConnection):
                     title="Harlequin encountered an error while executing your query.",
                 ) from e
             all_tables = cursor.fetchall_arrow()
-            all_tables = all_tables.sort_by([
-                ("table_catalog", "ascending"),
-                ("table_schema", "ascending"),
-                ("table_name", "ascending"),
-            ])
+            all_tables = all_tables.sort_by(
+                [
+                    ("table_catalog", "ascending"),
+                    ("table_schema", "ascending"),
+                    ("table_name", "ascending"),
+                ]
+            )
 
             cursor.execute(
                 """SELECT
@@ -252,12 +255,14 @@ class HarlequinDatabricksConnection(HarlequinConnection):
                 FROM system.information_schema.columns"""
             )
             all_cols = cursor.fetchall_arrow()
-            all_cols = all_cols.sort_by([
-                ("table_catalog", "ascending"),
-                ("table_schema", "ascending"),
-                ("table_name", "ascending"),
-                ("ordinal_position", "ascending"),
-            ])
+            all_cols = all_cols.sort_by(
+                [
+                    ("table_catalog", "ascending"),
+                    ("table_schema", "ascending"),
+                    ("table_name", "ascending"),
+                    ("ordinal_position", "ascending"),
+                ]
+            )
             unity_catalogs = all_tables["table_catalog"].unique()
 
             for catalog_arrow in unity_catalogs:

--- a/src/harlequin_databricks/adapter.py
+++ b/src/harlequin_databricks/adapter.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Sequence
 
+import pyarrow as pa
+import pyarrow.compute as pc
 from databricks import sql as databricks_sql
 from databricks.sql.client import Cursor as DatabricksCursor
 from harlequin import (
@@ -61,7 +63,10 @@ class HarlequinDatabricksCursor(HarlequinCursor):
             # as `string` data type for some reason:
             # https://github.com/databricks/databricks-sql-python/issues/336
             "INTERVAL": "|-|",
+            "LONG": "###",
             "MAP": "m",
+            "NULL": "nul",
+            "SHORT": "#",
             "SMALLINT": "#",
             "STRING": "s",
             "STRUCT": "{}",
@@ -86,6 +91,7 @@ class HarlequinDatabricksConnection(HarlequinConnection):
         options: dict[str, Any],
     ) -> None:
         self.init_message = init_message
+        self.skip_legacy_indexing = options.pop("skip_legacy_indexing")
         try:
             self.conn = databricks_sql.connect(**options)
         except Exception as e:
@@ -107,14 +113,22 @@ class HarlequinDatabricksConnection(HarlequinConnection):
         return HarlequinDatabricksCursor(cur)
 
     def get_catalog(self) -> Catalog:
+        catalog_items: list[CatalogItem] = []
+        catalog_items, seen_catalogs = self._get_unity_catalogs(catalog_items)
+
+        if self.skip_legacy_indexing:
+            return Catalog(items=catalog_items)
+
+        # Index legacy metastore metadata (e.g. `hive_metastore`):
         with self.conn.cursor() as cursor:
             cursor.catalogs()
             catalogs = cursor.fetchall_arrow()
             catalogs = catalogs.sort_by([("TABLE_CAT", "ascending")])
-            catalog_items: list[CatalogItem] = []
 
             for catalog_arrow in catalogs["TABLE_CAT"]:
                 catalog = catalog_arrow.as_py()
+                if catalog in seen_catalogs: continue
+                seen_catalogs.append(catalog)
 
                 cursor.schemas(catalog_name=catalog)
                 schemas = cursor.fetchall_arrow()
@@ -134,6 +148,7 @@ class HarlequinDatabricksConnection(HarlequinConnection):
                         tables["TABLE_TYPE"],
                     ):
                         table = table_arrow.as_py()
+
                         cursor.columns(
                             catalog_name=catalog, schema_name=schema, table_name=table
                         )
@@ -181,7 +196,135 @@ class HarlequinDatabricksConnection(HarlequinConnection):
                         children=schema_items,
                     )
                 )
+            # Sort the catalogs again to ensure legacy and unity catalogs appear alphabetically:
+            catalog_items = [
+                catalog_item for _, catalog_item in sorted(zip(seen_catalogs, catalog_items))
+            ]
             return Catalog(items=catalog_items)
+
+    def _get_unity_catalogs(
+        self,
+        catalog_items: list[CatalogItem],
+    ) -> tuple[list[CatalogItem], list[str]]:
+        """It is possible to index quickly assets on Databricks instances running Unity Catalog, as
+        only two SQL queries are required to fetch all Unity Catalog assets.
+
+        This method returns a list of Harlequin CatalogItems containing the Unity Catalog assets
+        (only) in the Databricks instance, and a list of the names of the Unity catalogs.
+
+        This method does not return metadata for any legacy Hive metastore assets, as that data
+        does not exist in `system.information_schema`:
+        https://docs.databricks.com/en/sql/language-manual/sql-ref-information-schema.html
+        """
+
+        with self.conn.cursor() as cursor:
+            try:
+                cursor.execute(
+                    """SELECT
+                    table_catalog
+                    , table_schema
+                    , table_name
+                    , table_type
+                    FROM system.information_schema.tables"""
+                )
+            except databricks_sql.ServerOperationError as e:
+                if e.message.startswith("[TABLE_OR_VIEW_NOT_FOUND]"):
+                    return catalog_items, []
+                raise HarlequinQueryError(
+                    msg=str(e),
+                    title="Harlequin encountered an error while executing your query.",
+                ) from e
+            all_tables = cursor.fetchall_arrow()
+            all_tables = all_tables.sort_by([
+                ("table_catalog", "ascending"),
+                ("table_schema", "ascending"),
+                ("table_name", "ascending"),
+            ])
+
+            cursor.execute(
+                """SELECT
+                  table_catalog
+                  , table_schema
+                  , table_name
+                  , column_name
+                  , ordinal_position
+                  , data_type
+                FROM system.information_schema.columns"""
+            )
+            all_cols = cursor.fetchall_arrow()
+            all_cols = all_cols.sort_by([
+                ("table_catalog", "ascending"),
+                ("table_schema", "ascending"),
+                ("table_name", "ascending"),
+                ("ordinal_position", "ascending"),
+            ])
+            unity_catalogs = all_tables["table_catalog"].unique()
+
+            for catalog_arrow in unity_catalogs:
+                catalog = catalog_arrow.as_py()
+
+                schemas = all_tables.filter(pc.field("table_catalog") == catalog_arrow)
+                schema_items: list[CatalogItem] = []
+
+                for schema_arrow in schemas["table_schema"].unique():
+                    schema = schema_arrow.as_py()
+
+                    tables = schemas.filter(pc.field("table_schema") == schema_arrow)
+                    table_items: list[CatalogItem] = []
+
+                    for table_arrow, table_type_arrow in zip(
+                        tables["table_name"],
+                        tables["table_type"],
+                    ):
+                        table = table_arrow.as_py()
+
+                        columns = all_cols.filter(
+                            (pc.field("table_catalog") == catalog_arrow)
+                            & (pc.field("table_schema") == schema_arrow)
+                            & (pc.field("table_name") == table_arrow)
+                        )
+                        column_items = [
+                            CatalogItem(
+                                qualified_identifier=(
+                                    f'"{catalog}"."{schema}"."{table}"."{column.as_py()}"'
+                                ),
+                                query_name=f'"{column.as_py()}"',
+                                label=column.as_py(),
+                                type_label=column_type.as_py(),
+                            )
+                            for column, column_type in zip(
+                                columns["column_name"], columns["data_type"]
+                            )
+                        ]
+
+                        table_items.append(
+                            CatalogItem(
+                                qualified_identifier=f'"{catalog}"."{schema}"."{table}"',
+                                query_name=f'"{catalog}"."{schema}"."{table}"',
+                                label=table,
+                                type_label=table_type_arrow.as_py(),
+                                children=column_items,
+                            )
+                        )
+                    schema_items.append(
+                        CatalogItem(
+                            qualified_identifier=f'"{catalog}"."{schema}"',
+                            query_name=f'"{catalog}"."{schema}"',
+                            label=schema,
+                            type_label="s",
+                            children=table_items,
+                        )
+                    )
+                catalog_items.append(
+                    CatalogItem(
+                        qualified_identifier=f'"{catalog}"',
+                        query_name=f'"{catalog}"',
+                        label=catalog,
+                        type_label="catalog",
+                        children=schema_items,
+                    )
+                )
+            return catalog_items, unity_catalogs.to_pylist()
 
     def get_completions(self) -> list[HarlequinCompletion]:
         return load_completions()
@@ -198,6 +341,7 @@ class HarlequinDatabricksAdapter(HarlequinAdapter):
         username: str | None = None,
         password: str | None = None,
         auth_type: str | None = None,
+        skip_legacy_indexing: bool | None = False,
         **_: Any,
     ) -> None:
         self.options = {
@@ -207,6 +351,7 @@ class HarlequinDatabricksAdapter(HarlequinAdapter):
             "username": username,
             "password": password,
             "auth_type": auth_type,
+            "skip_legacy_indexing": skip_legacy_indexing,
         }
 
     def connect(self) -> HarlequinDatabricksConnection:

--- a/src/harlequin_databricks/cli_options.py
+++ b/src/harlequin_databricks/cli_options.py
@@ -1,31 +1,28 @@
 from harlequin.options import FlagOption, SelectOption, TextOption
 
 server_hostname = TextOption(
-    name="server_hostname",
+    name="server-hostname",
     description="Databricks instance server hostname (ex. ****.cloud.databricks.com)",
-    short_decls=["--server-hostname"],
 )
 
 http_path = TextOption(
-    name="http_path",
+    name="http-path",
     description=(
         "HTTP path of either a Databricks SQL warehouse (ex. /sql/1.0/endpoints/1234567890abcdef)"
         "or a Databricks runtime interactive cluster (ex. "
         "/sql/protocolv1/o/1234567890123456/1234-123456-slid123)"
     ),
-    short_decls=["--http-path"],
     # 2024/01/28 Alex Malins: disabling these short_decls due to conflict with other adapters
     # (https://github.com/tconbeer/harlequin/issues/432ß):
-    # `"-p", "--path"`
+    # `"short_decls=[-p", "--path"]`
 )
 
 access_token = TextOption(
-    name="access_token",
+    name="access-token",
     description="Your Databricks personal access token (if using PAT authentication)",
-    short_decls=["--access-token"],
     # 2024/01/28 Alex Malins: disabling these short_decls due to conflict with other adapters
     # (https://github.com/tconbeer/harlequin/issues/432):
-    # `"-t", "--token"`
+    # `short_decls=["-t", "--token"]`
 )
 
 username = TextOption(
@@ -42,21 +39,19 @@ password = TextOption(
 )
 
 auth_type = SelectOption(
-    name="auth_type",
+    name="auth-type",
     description="Set to `databricks-oauth` if using OAuth user-to-machine (U2M) authentication",
     choices=["databricks-oauth"],
-    short_decls=["--auth-type"],
 )
 
 skip_legacy_indexing = FlagOption(
-    name="skip_legacy_indexing",
+    name="skip-legacy-indexing",
     description=(
-        "Skip the indexing of legacy metastores (e.g. `hive_metastore). Set this flag if your "
+        "Skip the indexing of legacy metastores (e.g. `hive_metastore`). Set this flag if your "
         "Databricks instance runs Unity Catalog and you do not want the overhead of slow indexing "
         "of assets in legacy metastores - i.e. you do not mind them not appearing in Harlequin's "
         "Data Catalog pane."
     ),
-    short_decls=["--skip-legacy-indexing"],
 )
 
 DATABRICKS_ADAPTER_OPTIONS = [

--- a/src/harlequin_databricks/cli_options.py
+++ b/src/harlequin_databricks/cli_options.py
@@ -1,4 +1,4 @@
-from harlequin.options import SelectOption, TextOption
+from harlequin.options import FlagOption, SelectOption, TextOption
 
 server_hostname = TextOption(
     name="server_hostname",
@@ -48,6 +48,17 @@ auth_type = SelectOption(
     short_decls=["--auth-type"],
 )
 
+skip_legacy_indexing = FlagOption(
+    name="skip_legacy_indexing",
+    description=(
+        "Skip the indexing of legacy metastores (e.g. `hive_metastore). Set this flag if your "
+        "Databricks instance runs Unity Catalog and you do not want the overhead of slow indexing "
+        "of assets in legacy metastores - i.e. you do not mind them not appearing in Harlequin's "
+        "Data Catalog pane."
+    ),
+    short_decls=["--skip-legacy-indexing"],
+)
+
 DATABRICKS_ADAPTER_OPTIONS = [
     server_hostname,
     http_path,
@@ -55,4 +66,5 @@ DATABRICKS_ADAPTER_OPTIONS = [
     username,
     password,
     auth_type,
+    skip_legacy_indexing,
 ]

--- a/src/harlequin_databricks/completions.py
+++ b/src/harlequin_databricks/completions.py
@@ -12,12 +12,12 @@ def load_completions() -> list[HarlequinCompletion]:
     keywords_path = Path(__file__).parent / "keywords.csv"
     with keywords_path.open("r") as file:
         reader = csv.reader(file, dialect="unix")
-        for name in reader:
+        for row in reader:
             completions.append(
                 HarlequinCompletion(
-                    label=name[0].lower(),
+                    label=row[0].lower(),
                     type_label="kw",
-                    value=name[0].lower(),
+                    value=row[0].lower(),
                     priority=1000,
                     context=None,
                 )

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -18,10 +18,10 @@ else:
 
 
 def test_plugin_discovery() -> None:
-    PLUGIN_NAME = "harlequin-databricks"
+    PLUGIN_NAME = "databricks"
     eps = entry_points(group="harlequin.adapter")
     assert eps[PLUGIN_NAME]
-    adapter_cls = eps[PLUGIN_NAME].load()
+    adapter_cls = eps[PLUGIN_NAME].load()  # type:ignore
     assert issubclass(adapter_cls, HarlequinAdapter)
     assert adapter_cls == HarlequinDatabricksAdapter
 


### PR DESCRIPTION
Release v0.2.0

### Features

-   Faster indexing for Unity Catalog assets. Makes loading & refreshing Harlequin's Data Catalog pane much quicker for Databricks instances running Unity Catalog. The new method fetches metadata for Unity Catalog assets from `system.information_schema`, requiring only two SQL queries to do so. This is much faster than the old method, which required separate SQL calls for each table. The old method is still in use for indexing legacy metastores (e.g. `hive_metastore`) however, as that metadata is not contained in Information schema: https://docs.databricks.com/en/sql/language-manual/sql-ref-information-schema.html
-   Add new command line flag `--skip-legacy-indexing` to skip the indexing of legacy metastores. Setting this flag is recommended if your Databricks instance runs Unity Catalog and you do not want the overhead of slow indexing of legacy metastores. When this flag is set, only Unity Catalog assets will show up in the Data Catalog pane.

### Bug Fixes

-   Fix minor formatting (black), types (mypy) & linting (ruff) issues, and a test failure.
-   Don't use underscores in CLI option names, i.e. make it so the only acceptable option version is the one written with hyphens not underscores.
-   Fix broken GitHub Action for PyPI releasing.