### PR TITLE
Add inititalization script & release 0.5.0

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -13,7 +13,7 @@ Note if you have a question about usage or a feature request, use the Discussion
 
 OS version: <!-- Windows 11/Linux/macOS etc. -->
 Python version: <!-- 3.8/3.9/3.10/3.11/3.12 -->
-harlequin-databricks version: <!-- ex. 0.4.0 -->
+harlequin-databricks version: <!-- ex. 0.5.0 -->
 harlequin version: <!-- ex. 1.24.0 -->
 Installed via: <!-- pip/conda-forge -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.0] - 2024-09-21
+
+## Features
+
+-   Add support for initialization scripts. By default harlequin-databricks will attempt to run an
+initialization script of SQL commands against Databricks from `~/.databricksrc` or from the file
+specified via the `--init-path` CLI option. This means you can e.g. set a default catalog
+(`USE CATALOG ...`), timezone, or set of user-defined variables for the session. It is possible to
+disable initialization via the `--no-init` CLI flag, having no  `~/.databricksrc` file, or feeding
+a non-existent file path to `--init-path`. (#14)
+
 ## [0.4.0] - 2024-09-01
 
 ## Features
@@ -74,7 +85,9 @@ is the one written with hyphens not underscores.
 
 -   Adds a Databricks adapter for SQL warehouses and DBR interactive clusters.
 
-[Unreleased]: https://github.com/alexmalins/harlequin-databricks/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/alexmalins/harlequin-databricks/compare/0.5.0...HEAD
+
+[0.5.0]: https://github.com/alexmalins/harlequin-databricks/compare/0.4.0...0.5.0
 
 [0.4.0]: https://github.com/alexmalins/harlequin-databricks/compare/0.3.1...0.4.0
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ poetry add harlequin[databricks]
 pipx install harlequin[databricks]
 ```
 
-## Usage and Configuration
+## Connecting to Databricks
 
 To connect to Databricks you are going to need to provide as CLI arguments:
 
@@ -138,9 +138,41 @@ So if your Databricks instance is running Unity Catalog, and you no longer care 
 metastores, setting the `--skip-legacy-indexing` CLI flag is recommended as it will mean
 much faster indexing & refreshing of the assets in the Data Catalog pane.
 
+## Initialization Scripts
+
+Each time you start Harlequin, it will execute SQL commands from a Databricks initialization script.
+For example:
+
+```sql
+USE CATALOG my_catalog;
+SET TIME ZONE 'Asia/Tokyo';
+DECLARE yesterday DATE DEFAULT CURRENT_DATE - INTERVAL '1' DAY;
+```
+
+Multi-line SQL is allowed, but must be terminated by a semicolon.
+
+### Configuring the Script Location
+
+By default, Harlequin will execute the script found at `~/.databricksrc`. However, you can provide
+a different path using the `--init-path` option (aliased to `-i` or `-init`):
+
+```bash
+harlequin -a databricks --init-path /path/to/my/script.sql
+```
+
+### Disabling Initialization
+
+If you would like to open Harlequin without running the script you have at `~/.databricksrc`, you
+can either pass a nonexistent path (or `/dev/null`) to the option above, or start Harlequin with
+the `--no-init` option:
+
+```bash
+harlequin -a databricks --no-init
+```
+
 ## Other CLI options:
 
-For more details on command line options, run:
+For more details on other command line options, run:
 
 ```bash
 harlequin --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harlequin-databricks"
-version = "0.4.0"
+version = "0.5.0"
 description = "A Harlequin adapter for Databricks."
 authors = [
     "Zach Shirah <zachshirah01@gmail.com>",

--- a/src/harlequin_databricks/cli_options.py
+++ b/src/harlequin_databricks/cli_options.py
@@ -1,4 +1,6 @@
-from harlequin.options import FlagOption, SelectOption, TextOption
+from pathlib import Path
+
+from harlequin.options import FlagOption, PathOption, SelectOption, TextOption
 
 server_hostname = TextOption(
     name="server-hostname",
@@ -75,6 +77,25 @@ client_secret = TextOption(
     ),
 )
 
+init_path = PathOption(
+    name="init-path",
+    description=(
+        "The path to an initialization script. On startup, Harlequin will execute "
+        "the commands in the script against the attached database."
+    ),
+    short_decls=["-i", "-init"],
+    exists=False,
+    file_okay=True,
+    dir_okay=False,
+    resolve_path=True,
+    path_type=Path,
+)
+
+no_init = FlagOption(
+    name="no-init",
+    description="Start Harlequin without executing the initialization script.",
+)
+
 DATABRICKS_ADAPTER_OPTIONS = [
     server_hostname,
     http_path,
@@ -85,4 +106,6 @@ DATABRICKS_ADAPTER_OPTIONS = [
     skip_legacy_indexing,
     client_id,
     client_secret,
+    init_path,
+    no_init,
 ]


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->

#### What does this PR implement/fix?

Add support for initialization scripts. By default harlequin-databricks will attempt to run an initialization script of SQL commands against Databricks from `~/.databricksrc` or from the file specified via the `--init-path` CLI option. This means you can e.g. set a default catalog (`USE CATALOG ...`), timezone, or set of user-defined variables for the session. It is possible to disable initialization via the `--no-init` CLI flag, having no  `~/.databricksrc` file, or feeding
a non-existent file path to `--init-path`.

#### Fixes Issue

#14


#### Other comments?

Implementation follows that of the DuckDB and SQLite adapters. It does not implement running dot commands, as I don't think such a thing exists for Databricks.
