### PR TITLE
Bug fix: resolve initialization script paths starting with ~ & release v0.5.1

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -13,7 +13,7 @@ Note if you have a question about usage or a feature request, use the Discussion
 
 OS version: <!-- Windows 11/Linux/macOS etc. -->
 Python version: <!-- 3.8/3.9/3.10/3.11/3.12 -->
-harlequin-databricks version: <!-- ex. 0.5.0 -->
+harlequin-databricks version: <!-- ex. 0.5.1 -->
 harlequin version: <!-- ex. 1.24.0 -->
 Installed via: <!-- pip/conda-forge -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] - 2024-09-21
+
+### Bug Fixes
+
+-   Fix bug to properly resolve initialization script paths starting with `~` (i.e. user's home
+dir) supplied to `--init-path`.
+
 ## [0.5.0] - 2024-09-21
 
-## Features
+### Features
 
 -   Add support for initialization scripts. By default harlequin-databricks will attempt to run an
 initialization script of SQL commands against Databricks from `~/.databricksrc` or from the file
@@ -17,7 +24,7 @@ a non-existent file path to `--init-path`. (#14)
 
 ## [0.4.0] - 2024-09-01
 
-## Features
+### Features
 
 -   Add support for cancelling queries mid-flight. Requires Harlequin `>=1.24.0` which introduced
 the "Cancel Query" button.
@@ -85,7 +92,9 @@ is the one written with hyphens not underscores.
 
 -   Adds a Databricks adapter for SQL warehouses and DBR interactive clusters.
 
-[Unreleased]: https://github.com/alexmalins/harlequin-databricks/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/alexmalins/harlequin-databricks/compare/0.5.1...HEAD
+
+[0.5.1]: https://github.com/alexmalins/harlequin-databricks/compare/0.5.0...0.5.1
 
 [0.5.0]: https://github.com/alexmalins/harlequin-databricks/compare/0.4.0...0.5.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harlequin-databricks"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Harlequin adapter for Databricks."
 authors = [
     "Zach Shirah <zachshirah01@gmail.com>",

--- a/src/harlequin_databricks/adapter.py
+++ b/src/harlequin_databricks/adapter.py
@@ -531,7 +531,7 @@ class HarlequinDatabricksAdapter(HarlequinAdapter):
     ) -> None:
         try:
             init_path = (
-                Path(init_path).resolve()
+                Path(init_path).expanduser().resolve()
                 if init_path is not None
                 else Path.home() / ".databricksrc"
             )


### PR DESCRIPTION


<!-- Thank you for contributing to this project! -->

#### What does this PR implement/fix?

Fix bug to properly resolve initialization script paths starting with `~` (i.e. user's home dir) supplied to `--init-path`.

Using only `.resolve()` means a path like `~/.my_startup.sql` resolves to `/Users/me/~/.my_startup.sql` which does not exist.

Using `.expanduser.resolve()` means the path properly resolves to `/Users/me/.my_startup.sql`.

#### Fixes Issue
<!-- Example: Issue #5 or N/A -->


#### Other comments?
